### PR TITLE
feat: implement publish by name, safely escape query parameters

### DIFF
--- a/publish.go
+++ b/publish.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/url"
 )
 
 const publishPath = "authenticated/publish"
@@ -11,10 +12,27 @@ const publishPath = "authenticated/publish"
 // PublishService handles communication to the publish API endpoint
 type PublishService service
 
-// Publish sends data to a specified pipeline. The data input is sent as the
-// body of the request.
-func (s *PublishService) Publish(ctx context.Context, pipelineID string, data interface{}) (*http.Response, error) {
-	path := fmt.Sprintf("%s?pipelineId=%s", publishPath, pipelineID)
+// Publish sends data to a specified pipeline by it's name. The data input is
+// sent as the body of the request.
+func (s *PublishService) Publish(ctx context.Context, pipelineName string, data interface{}) (*http.Response, error) {
+	path := fmt.Sprintf("%s?name=%s", publishPath, url.QueryEscape(pipelineName))
+	req, err := s.client.NewRequestWithCustomerURL("POST", path, data)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := s.client.DoRequest(ctx, req, nil)
+	if err != nil {
+		return resp, err
+	}
+
+	return resp, nil
+}
+
+// PublishByID sends data to a specified pipeline by it's ID. The data input is
+// sent as the body of the request.
+func (s *PublishService) PublishByID(ctx context.Context, pipelineID string, data interface{}) (*http.Response, error) {
+	path := fmt.Sprintf("%s?id=%s", publishPath, url.QueryEscape(pipelineID))
 	req, err := s.client.NewRequestWithCustomerURL("POST", path, data)
 	if err != nil {
 		return nil, err

--- a/publish_test.go
+++ b/publish_test.go
@@ -9,11 +9,35 @@ import (
 )
 
 const (
-	testPublishPipelineID = "ABC123"
+	testPublishPipelineName = "testPipeline"
+	testPublishPipelineID   = "ABC123"
 )
 
 func TestPublish_Publish(t *testing.T) {
+	client, mux, teardown := setup()
+	defer teardown()
 
+	mux.HandleFunc("/authenticated/publish", func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "POST", r.Method)
+		require.Contains(t, r.Header, "Authorization")
+	})
+
+	ctx := context.Background()
+	data := struct {
+		TestKey string
+	}{
+		TestKey: "TestValue",
+	}
+	// validate a generic publish attempt
+	_, err := client.Publish.Publish(ctx, testPublishPipelineName, data)
+	require.NoError(t, err)
+
+	// ensure that query parameters are safely escaped
+	_, err = client.Publish.Publish(ctx, "pipeline with spaces", data)
+	require.NoError(t, err)
+}
+
+func TestPublish_PublishByID(t *testing.T) {
 	client, mux, teardown := setup()
 	defer teardown()
 


### PR DESCRIPTION
add a PublishByID method to the publish service, refactor publish to
publish by name, since that is the more likely usecase of the publish
service.

add escaping to query parameters to prevent "unexpected EOF" when
pipelines with spaces are supplied.

update tests.